### PR TITLE
Auto fallback to loopback address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/). All notable changes will be documented in this file.
 
+## [Unreleased](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v1.6.5...HEAD)
+- Fixed: Fall back to 127.0.0.1 when pg-tunnel.borealis-data.com cannot be resolved
+
 ## [1.6.5](https://github.com/OldSneerJaw/borealis-pg-cli/compare/v1.6.4...v1.6.5)
 - Fixed: Missing files when building and publishing
 

--- a/src/commands/borealis-pg/psql.ts
+++ b/src/commands/borealis-pg/psql.ts
@@ -10,7 +10,7 @@ import {
   cliOptions,
   consoleColours,
   formatCliOptionName,
-  localPgHostname,
+  getLocalPgHost,
   portOptionName,
   processAddonAttachmentInfo,
   writeAccessOptionName,
@@ -85,8 +85,10 @@ pgAdmin).`
       addonInfo,
       flags[writeAccessOptionName])
 
+    const localPgHost = await getLocalPgHost()
+
     this.executePsql(
-      {ssh: sshConnInfo, db: dbConnInfo, localPgPort: flags.port},
+      {ssh: sshConnInfo, db: dbConnInfo, localPgHost, localPgPort: flags.port},
       customBinaryPath ?? 'psql')
 
     // Prevent Ctrl+C from ending the process
@@ -139,7 +141,7 @@ pgAdmin).`
       sshClient => tunnelServices.childProcessFactory.spawn(psqlPath, {
         env: {
           ...tunnelServices.nodeProcess.env,
-          PGHOST: localPgHostname,
+          PGHOST: connInfo.localPgHost,
           PGPORT: connInfo.localPgPort.toString(),
           PGDATABASE: connInfo.db.dbName,
           PGUSER: connInfo.db.dbUsername,

--- a/src/ssh-tunneling.test.ts
+++ b/src/ssh-tunneling.test.ts
@@ -51,6 +51,7 @@ const fakeCompleteConnInfo = {
     sshPrivateKey: fakeSshPrivateKey,
     publicSshHostKey: expectedSshHostKeyEntry,
   },
+  localPgHost: localPgHostname,
   localPgPort: customPgPort,
 }
 
@@ -67,6 +68,7 @@ const fakeNoPortsConnInfo = {
     sshPrivateKey: fakeSshPrivateKey,
     publicSshHostKey: expectedSshHostKeyEntry,
   },
+  localPgHost: localPgHostname,
   localPgPort: defaultPgPort,
 }
 

--- a/src/ssh-tunneling.ts
+++ b/src/ssh-tunneling.ts
@@ -2,12 +2,7 @@ import childProcess, {SpawnOptions} from 'child_process'
 import {createServer, Server, Socket} from 'net'
 import {Client as PgClient, ClientConfig as PgClientConfig} from 'pg'
 import {Client as SshClient, ServerHostKeyAlgorithm} from 'ssh2'
-import {
-  defaultPorts,
-  formatCliOptionName,
-  localPgHostname,
-  portOptionName,
-} from './command-components'
+import {defaultPorts, formatCliOptionName, portOptionName} from './command-components'
 
 const addressInUseErrorCode = 'EADDRINUSE'
 const permissionDeniedErrorCode = 'EACCES'
@@ -66,7 +61,7 @@ function initProxyServer(
     })
 
     sshClient.forwardOut(
-      localPgHostname,
+      connInfo.localPgHost,
       connInfo.localPgPort,
       connInfo.db.dbHost,
       connInfo.db.dbPort ?? defaultPorts.pg,
@@ -96,7 +91,7 @@ function initProxyServer(
     } else {
       logger.error(err)
     }
-  }).listen(connInfo.localPgPort, localPgHostname)
+  }).listen(connInfo.localPgPort, connInfo.localPgHost)
 }
 
 function initSshClient(
@@ -147,6 +142,7 @@ export interface DbConnectionInfo {
 export interface FullConnectionInfo {
   db: DbConnectionInfo;
   ssh: SshConnectionInfo;
+  localPgHost: string;
   localPgPort: number;
 }
 


### PR DESCRIPTION
The pg-tunnel.borealis-data.com DNS record cannot be resolved when the network is configured to block DNS rebinding, so fall back to using 127.0.0.1 for SSH local port forwarding in such cases.