### PR TITLE
Switch to npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,4 @@ jobs:
         run: yarn install --immutable --immutable-cache --check-cache
 
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance --tag ${{ github.event.inputs.tag }}


### PR DESCRIPTION
Eliminates reliance on a long-lived npm access token in GitHub Actions when publishing new versions of the package to npm.